### PR TITLE
Add #ifdef in Vector/Matrix/Color fields for Unity 2022.1

### DIFF
--- a/Editor/Controls/VFXMatrix4x4Field.cs
+++ b/Editor/Controls/VFXMatrix4x4Field.cs
@@ -4,7 +4,11 @@ using UnityEditor.UIElements;
 
 using Action = System.Action;
 
+#if UNITY_2022_1_OR_NEWER
+using FloatField = UnityEditor.VFX.UI.VFXLabeledField<UnityEngine.UIElements.FloatField, float>;
+#else
 using FloatField = UnityEditor.VFX.UI.VFXLabeledField<UnityEditor.UIElements.FloatField, float>;
+#endif
 
 namespace UnityEditor.VFX.UI
 {

--- a/Editor/Controls/VFXVector2Field.cs
+++ b/Editor/Controls/VFXVector2Field.cs
@@ -3,7 +3,11 @@ using UnityEngine.UIElements;
 using UnityEditor.UIElements;
 using System.Collections.Generic;
 
+#if UNITY_2022_1_OR_NEWER
+using FloatField = UnityEditor.VFX.UI.VFXLabeledField<UnityEngine.UIElements.FloatField, float>;
+#else
 using FloatField = UnityEditor.VFX.UI.VFXLabeledField<UnityEditor.UIElements.FloatField, float>;
+#endif
 
 namespace UnityEditor.VFX.UI
 {

--- a/Editor/Controls/VFXVector3Field.cs
+++ b/Editor/Controls/VFXVector3Field.cs
@@ -4,7 +4,12 @@ using UnityEditor.UIElements;
 
 using Action = System.Action;
 
+#if UNITY_2022_1_OR_NEWER
+using FloatField = UnityEditor.VFX.UI.VFXLabeledField<UnityEngine.UIElements.FloatField, float>;
+#else
 using FloatField = UnityEditor.VFX.UI.VFXLabeledField<UnityEditor.UIElements.FloatField, float>;
+#endif
+
 namespace UnityEditor.VFX.UI
 {
     abstract class VFXVectorNField<T> : VFXControl<T>

--- a/Editor/GraphView/Views/Properties/ColorPropertyRM.cs
+++ b/Editor/GraphView/Views/Properties/ColorPropertyRM.cs
@@ -2,8 +2,11 @@
 
 using UnityEngine;
 using UnityEngine.UIElements;
+#if UNITY_2022_1_OR_NEWER
+using FloatField = UnityEditor.VFX.UI.VFXLabeledField<UnityEngine.UIElements.FloatField, float>;
+#else
 using FloatField = UnityEditor.VFX.UI.VFXLabeledField<UnityEditor.UIElements.FloatField, float>;
-
+#endif
 
 namespace UnityEditor.VFX.UI
 {


### PR DESCRIPTION
In Unity 2022.1 `FloatField` have been moved to `UnityEngine.UIElements` namespace.
